### PR TITLE
Update post_creator.rb

### DIFF
--- a/app/services/post_creator.rb
+++ b/app/services/post_creator.rb
@@ -24,12 +24,12 @@ class ::Babble::PostCreator < ::PostCreator
     false
   end
 
-  def trigger_after_events(post)
+  def trigger_after_events
     super
 
-    post.trigger_post_process(true)
+    @post.trigger_post_process(true)
     TopicUser.update_last_read(@user, @topic.id, @post.post_number, @post.post_number, PostTiming::MAX_READ_TIME_PER_BATCH)
-    PostAlerter.post_created(post)
+    PostAlerter.post_created(@post)
 
     Babble::Broadcaster.publish_to_posts(@post, @user)
     Babble::Broadcaster.publish_to_topic(@topic, @user)


### PR DESCRIPTION
Seems that latest version of Discourse changed trigger_after_events method, it no longer wants post parameter (and instead uses instance @post variable). This fix seems to work on my development server at the very least.